### PR TITLE
160376746: Caterers can manage all menus for all days of the week

### DIFF
--- a/src/BookAMeal.css
+++ b/src/BookAMeal.css
@@ -253,6 +253,10 @@ input[type=text]:focus, input[type=password]:focus {
     background: #f9f9f9;
   }
 
+  #manageMenu{
+      margin-bottom: 30px;
+  }
+
 /* Change styles for cancel button and signup button on extra small screens */
 @media screen and (max-width: 300px) {
     .cancelbtn, .signupbtn, .signinbtn {

--- a/src/components/common/forms/setupMenuBtn.js
+++ b/src/components/common/forms/setupMenuBtn.js
@@ -3,7 +3,7 @@ import React from 'react';
 const SetupMenuBtn = ({onSetupMenu}) => {
     return(
         <input type="submit"
-            value="Setup Menu"
+            value="Manage Menus"
             className="btn btn-primary btn-sm"
             onClick={onSetupMenu}
             />

--- a/src/components/menu/DailyMenu.js
+++ b/src/components/menu/DailyMenu.js
@@ -1,0 +1,24 @@
+import React from "react";
+import PropTypes from 'prop-types'
+
+const DailyMenu = ({menu}) => {
+    return (
+        <div className="col-md-4">
+            <div className="panel panel-info">
+                <div className="panel-heading">
+                    <h2 style={{'margin':'5px'}}>{menu.day.name}</h2>                 
+                </div>
+                <div className="panel-body">
+                    <ul className="list-group">
+                    {menu.mealList &&
+                        menu.mealList.map(meal =>
+                            <li className="list-group-item">{meal.name} - ${meal.price}</li>
+                        )}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default DailyMenu;

--- a/src/components/menu/ManageMenuPage.js
+++ b/src/components/menu/ManageMenuPage.js
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types'
 import { withRouter } from 'react-router'
 import {connect} from 'react-redux';
+import { history } from '../../helpers/history';
 import {menuActions} from '../../actions/menu.actions';
 import {alertActions} from '../../actions/alert.actions';
 import { daysFormattedForDropdown } from '../common/selectors'
 import MenuForm from './MenuForm';
+import DailyMenu from './DailyMenu'
 
 export class ManageMenuPage extends React.Component {
   constructor(props, context) {
@@ -13,6 +15,7 @@ export class ManageMenuPage extends React.Component {
 
     this.state = {
       menu: Object.assign({}, this.props.menu),
+      menus: this.props.menus,
       meals: this.props.meals,
       errors: {},
       creating: false,
@@ -25,6 +28,7 @@ export class ManageMenuPage extends React.Component {
     this.createMenu = this.createMenu.bind(this);
     this.onMealChecked = this.onMealChecked.bind(this);
     this.onDaySelected = this.onDaySelected.bind(this);
+    this.cancelManageMenu = this.cancelManageMenu.bind(this);
   }
 
     updateMenuState(event) {
@@ -42,8 +46,8 @@ export class ManageMenuPage extends React.Component {
         let day = parseInt(this.state.selectedDay,10);
         this.props.createMenu(day, selectedMeals);
         this.setState({selectedMeals: [], selectedDay: null})
-
-        this.redirect("Menu has been updated");
+        this.setState({creating: false});
+        history.push("/dashboard")
     }
     
     redirect(message) {
@@ -73,26 +77,40 @@ export class ManageMenuPage extends React.Component {
         this.setState({selectedMeals});
     }
 
+    cancelManageMenu(){
+        this.context.router.history.push('/dashboard');
+    }
+
     render() {
         const {days} = this.props
+        const {menus} = this.state
         return (
             <div className="wrapper">
                 <div className="row">
-                    <div className="col-md-10">
+                    <div className="col-md-12">
                         <div className="mainContent">
-                            <div className="col-md-6 col-md-offset-1">
+                            <div className="row">
+                                <div className="col-md-8 col-md-offset-1">
                                 <MenuForm
                                     meals={this.state.meals}
                                     onChange={this.updateOrderState}
                                     onCreateMenu={this.createMenu}
                                     onMealToggle={this.onMealChecked}
                                     onSelectDay={this.onDaySelected}
+                                    onCancel={this.cancelManageMenu}
                                     selectedDay={this.state.selectedDay}
                                     allDays={days}
                                     menu={this.state.menu}
                                     errors={this.state.errors}
                                     creating={this.state.creating}
                                 />
+                            </div>
+                            </div>
+                            <div className="row">
+                                <div className="col-md-12">
+                                    { menus && menus.map(menu => 
+                                        <DailyMenu key={menu.day.id} menu={menu}/>)}
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -113,6 +131,7 @@ ManageMenuPage.contextTypes = {
 };
 
 function mapStateToProps(state, ownProps) {
+    const { menus } = state
     const meals = ownProps.location.state.meals;
     let menu = ownProps.location.state.menu;
     let days = [
@@ -147,6 +166,7 @@ function mapStateToProps(state, ownProps) {
     ]
     days = daysFormattedForDropdown(days);
     return {
+        menus,
         menu,
         days,
         meals

--- a/src/components/menu/MenuForm.js
+++ b/src/components/menu/MenuForm.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import SelectInput from '../common/forms/selectInput';
 import MealCheckboxList from './MealCheckboxList';
 
-const MenuForm = ({menu, meals, allDays, onCreateMenu, onMealToggle, selectedDay, onSelectDay, creating, errors}) => {
+const MenuForm = ({menu, meals, allDays, onCreateMenu, onMealToggle, selectedDay, onSelectDay, creating, errors, onCancel}) => {
     let day = null;
     if(selectedDay === null){
         day = "Select a day"
@@ -37,7 +37,7 @@ const MenuForm = ({menu, meals, allDays, onCreateMenu, onMealToggle, selectedDay
     }
     
     return (
-        <form>
+        <form id="manageMenu">
             <h1>Manage Daily Menus</h1>
             <SelectInput
                 label="Select a Day"
@@ -55,12 +55,20 @@ const MenuForm = ({menu, meals, allDays, onCreateMenu, onMealToggle, selectedDay
                     onMealToggle={onMealToggle}/>
             </div>
             <br/>
-            <input
-                type="submit"
-                disabled={creating}
-                value={creating ? 'Creating Menu...': 'Create Menu'}
-                className="btn btn-primary btn-sm"
-                onClick={onCreateMenu}/>
+            <div className="btn-toolbar">
+                <input
+                    type="submit"
+                    disabled={creating}
+                    value={creating ? 'Creating Menu...': 'Create Menu'}
+                    className="btn btn-primary btn-sm"
+                    onClick={onCreateMenu}/>
+
+                <input
+                    type="submit"
+                    value='Cancel'
+                    className="btn btn-danger btn-sm"
+                    onClick={onCancel}/>
+            </div>
         </form>
   );
 };
@@ -71,7 +79,7 @@ MenuForm.propTypes = {
   onSave: PropTypes.func.isRequired,
   onCreateMenu: PropTypes.func.isRequired,
   onMealToggle: PropTypes.func.isRequired,
-  selectedDay: PropTypes.object.isRequired,
+  selectedDay: PropTypes.object,
   onSelectDay: PropTypes.func.isRequired,
   creating: PropTypes.bool,
   errors: PropTypes.object


### PR DESCRIPTION
#### What does this PR do?
It implements a feature which allows caterers to manage menus for all 7 days of the week

#### Description of Task to be completed?
- Add a new component to display individual menus
- Add the newly created menu component to the `ManageMenuPage` component

#### How should this be manually tested?
After cloning the repository;
- Run the application using the command `npm start`
- Login as a caterer 
- In `Daily Menu` section of the `Caterer admin dashboard`, click the button labelled `Manage Menus`
- The `Manage Menu` Page is displayed where you can can view and edit menus for any day of the week 
#### Any background context you want to provide?
A caterer was initially only able to setup a menu for the day, this addition allows a caterer to manage multiple menus for all days of the week

#### What are the relevant pivotal tracker stories?
[#160376746](https://www.pivotaltracker.com/story/show/160376746)

#### Screenshots
- Login 
<img width="1429" alt="screen shot 2018-09-11 at 10 50 50" src="https://user-images.githubusercontent.com/4680759/45346015-add3a380-b5b0-11e8-9929-94cf15ee13fa.png">

- Click `Manage Menus` button on dashboard
<img width="1270" alt="screen shot 2018-09-11 at 10 51 12" src="https://user-images.githubusercontent.com/4680759/45346047-c17f0a00-b5b0-11e8-98ab-ae371acf0ecc.png">

- Manage Menus for different days
<img width="1421" alt="screen shot 2018-09-11 at 10 50 31" src="https://user-images.githubusercontent.com/4680759/45346080-d6f43400-b5b0-11e8-92dc-35d1783f7339.png">
